### PR TITLE
Stripe integration - HPP 

### DIFF
--- a/apps/payments/app/[locale]/(embedded)/paymentRequest/pay/page.tsx
+++ b/apps/payments/app/[locale]/(embedded)/paymentRequest/pay/page.tsx
@@ -177,20 +177,39 @@ export default async function Page(props: Props) {
             <hr className="govie-section-break govie-section-break--visible"></hr>
           </>
         )}
-        <div style={{ margin: "1em 0" }}>
-          <h3 className="govie-heading-s">{t("payByCard")}</h3>
-          {hasStripe && (
+        {hasStripe && (
+          <>
+            <div style={{ margin: "1em 0" }}>
+              <h3 className="govie-heading-s">
+                {t("payByCard")} - Custom flow
+              </h3>
+              <ClientLink
+                label={t("payNow")}
+                href={getPaymentUrl(
+                  props.searchParams!.paymentId,
+                  "stripe",
+                  props.searchParams!.id,
+                  urlAmount,
+                )}
+              />
+            </div>
+            <hr className="govie-section-break govie-section-break--visible"></hr>
+          </>
+        )}
+        {hasStripe && (
+          <div style={{ margin: "1em 0" }}>
+            <h3 className="govie-heading-s">{t("payByCard")} - HPP flow</h3>
             <ClientLink
               label={t("payNow")}
               href={getPaymentUrl(
                 props.searchParams!.paymentId,
-                "stripe",
+                "stripeHPP",
                 props.searchParams!.id,
                 urlAmount,
               )}
             />
-          )}
-        </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/payments/app/[locale]/(hosted)/paymentRequest/stripeHPP/StripeCheckout.tsx
+++ b/apps/payments/app/[locale]/(hosted)/paymentRequest/stripeHPP/StripeCheckout.tsx
@@ -1,0 +1,37 @@
+"use client";
+import { loadStripe } from "@stripe/stripe-js";
+import { useEffect, useState } from "react";
+
+type Props = {
+  sessionId: string;
+};
+
+const PUBLISHABLE_KEY = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
+
+if (!PUBLISHABLE_KEY)
+  throw Error("Missing env var NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY");
+
+const stripePromise = loadStripe(PUBLISHABLE_KEY);
+
+export default function StripeHost({ sessionId }: Props) {
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const redirect = async () => {
+      const stripe = await stripePromise;
+      if (!stripe) throw Error("Stripe not loaded");
+      const result = await stripe.redirectToCheckout({
+        sessionId,
+      });
+      if (result.error) {
+        // TODO: redirect
+        setError(result.error?.message ?? "An unknown error occurred");
+      }
+      return result;
+    };
+
+    redirect();
+  }, []);
+
+  return <div>{error && <div>Error: {error}</div>}</div>;
+}

--- a/apps/payments/app/[locale]/(hosted)/paymentRequest/stripeHPP/page.tsx
+++ b/apps/payments/app/[locale]/(hosted)/paymentRequest/stripeHPP/page.tsx
@@ -1,0 +1,99 @@
+import { PgSessions, getUserInfoById } from "auth/sessions";
+import { pgpool } from "../../../../dbConnection";
+import { getTranslations } from "next-intl/server";
+import { createCheckoutSession } from "../../../../integration/stripe";
+import StripeCheckout from "./StripeCheckout";
+
+async function getPaymentDetails(paymentId: string) {
+  "use server";
+  const { rows } = await pgpool.query(
+    `
+    select
+      pr.payment_request_id,
+      pr.user_id,
+      pr.title,
+      pr.description,
+      pr.reference,
+      pr.amount,
+      pp.provider_id,
+      pp.provider_name,
+      pp.provider_data
+    from payment_requests pr
+    join payment_requests_providers ppr on pr.payment_request_id = ppr.payment_request_id
+    join payment_providers pp on ppr.provider_id = pp.provider_id
+    where pr.payment_request_id = $1
+      and pp.provider_type = 'stripe'
+    `,
+    [paymentId],
+  );
+
+  if (!rows.length) return undefined;
+
+  const userInfo = await getUserInfoById(rows[0].user_id);
+
+  if (!userInfo) return undefined;
+
+  return {
+    ...rows[0],
+    govid_email: userInfo.govid_email,
+    user_name: userInfo.user_name,
+  };
+}
+
+async function createTransaction(
+  paymentId: string,
+  userId: string,
+  extPaymentId: string,
+  tenantReference: string,
+) {
+  "use server";
+  await pgpool.query<{ transaction_id: number }>(
+    `
+      insert into payment_transactions (payment_request_id, user_id, ext_payment_id, integration_reference, status, created_at, updated_at)
+      values ($1, $2, $3, $4, 'pending', now(), now());
+      `,
+    [paymentId, userId, extPaymentId, tenantReference],
+  );
+}
+
+export default async function Card(props: {
+  params: { locale: string };
+  searchParams: { paymentId: string; integrationRef: string } | undefined;
+}) {
+  const t = await getTranslations("Common");
+  if (!props.searchParams?.paymentId) {
+    return <h1>{t("notFound")}</h1>;
+  }
+  const { userId } = await PgSessions.get();
+
+  const paymentDetails = await getPaymentDetails(props.searchParams.paymentId);
+
+  const returnUri = new URL(
+    `/${props.params.locale}/paymentRequest/complete`,
+    process.env.HOST_URL,
+  ).toString();
+
+  const session = await createCheckoutSession(paymentDetails, returnUri);
+
+  // TODO: we're storing the checkout session id here as external payment id.
+  // should be later used with webhooks to retrieve payment status
+  await createTransaction(
+    props.searchParams.paymentId,
+    userId,
+    session.id,
+    props.searchParams.integrationRef,
+  );
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        marginTop: "2em",
+      }}
+    >
+      <StripeCheckout sessionId={session.id} />
+    </div>
+  );
+}

--- a/apps/payments/app/integration/stripe.ts
+++ b/apps/payments/app/integration/stripe.ts
@@ -10,3 +10,24 @@ export async function createPaymentIntent(paymentRequest) {
 export async function getPaymentIntent(clientSecret) {
   return await stripe.paymentIntents.retrieve(clientSecret);
 }
+
+export async function createCheckoutSession(paymentRequest, returnUri) {
+  return await stripe.checkout.sessions.create({
+    payment_method_types: ["card", "paypal"],
+    line_items: [
+      {
+        price_data: {
+          currency: "EUR",
+          unit_amount: paymentRequest.amount,
+          product_data: {
+            name: "Your Product",
+          },
+        },
+        quantity: 1,
+      },
+    ],
+    mode: "payment",
+    success_url: returnUri,
+    cancel_url: returnUri,
+  });
+}


### PR DESCRIPTION
Add an additional payment method to pay with Stripe using their hosted payments page.
This piece of work is just to explore the differences between the integrations with their HPP or custom flow, especially in terms of UI.
HPP methods allows very little customization, in the following screenshot it's **not** customized.

Custom flow:
![Screenshot 2024-03-18 at 16 42 56](https://github.com/ogcio/life-events/assets/47299026/b7a00c8e-2959-43eb-bda2-23191564c868)

HPP flow:
![Screenshot 2024-03-18 at 16 44 17](https://github.com/ogcio/life-events/assets/47299026/222b8839-a5ec-45e0-a9cf-5f312febb427)
