### PR TITLE
Fix translations in 'local health offices' async component

### DIFF
--- a/apps/web/app/[locale]/[event]/[...action]/OrderEHIC/LocalHealthOfficeForm.tsx
+++ b/apps/web/app/[locale]/[event]/[...action]/OrderEHIC/LocalHealthOfficeForm.tsx
@@ -1,6 +1,6 @@
-import { useTranslations } from "next-intl";
 import { postgres, workflow } from "../../../../utils";
 import { redirect } from "next/navigation";
+import { getTranslations } from "next-intl/server";
 
 type FormProps = {
   userId: string;
@@ -9,7 +9,7 @@ type FormProps = {
 };
 
 export default async (props: FormProps) => {
-  const t = useTranslations("LocalHealthOfficeForm");
+  const t = await getTranslations("LocalHealthOfficeForm");
   const selectName = "selected-health-office";
 
   const healthOfficesResponse = await fetch(


### PR DESCRIPTION
Replace `useTranslations` with `await getTranslations` in async component (see: https://next-intl-docs.vercel.app/docs/environments/server-client-components#async-components and same error reported here: https://github.com/vercel/next.js/issues/51477). 

This was causing an intermittent runtime error: `Error: Expected a suspended thenable. This is a bug in React. Please file an issue.`