### PR TITLE
Delete payment request

### DIFF
--- a/apps/payments/app/[locale]/(hosted)/paymentSetup/requests/[requestId]/page.tsx
+++ b/apps/payments/app/[locale]/(hosted)/paymentSetup/requests/[requestId]/page.tsx
@@ -28,6 +28,30 @@ async function createTransaction(requestId: string, formData: FormData) {
   redirect(requestId);
 }
 
+async function deletePaymentRequest(requestId: string) {
+  "use server";
+
+  await pgpool.query(
+    `
+    delete from payment_requests where payment_request_id = $1
+    `,
+    [requestId],
+  );
+
+  redirect("/paymentSetup/requests");
+}
+
+async function hasTransactions(requestId: string) {
+  const { rows } = await pgpool.query<{ transaction_id: number }>(
+    `
+    select transaction_id from payment_transactions where payment_request_id = $1
+    `,
+    [requestId],
+  );
+
+  return rows.length > 0;
+}
+
 export const RequestDetails = async ({ requestId }: { requestId: string }) => {
   const details = await getPaymentRequestDetails(requestId);
   const t = await getTranslations("PaymentSetup.CreatePayment");
@@ -37,6 +61,10 @@ export const RequestDetails = async ({ requestId }: { requestId: string }) => {
   if (!details) {
     return <h1 className="govie-heading-l">Payment request not found</h1>;
   }
+
+  const deletePR = deletePaymentRequest.bind(this, details.payment_request_id);
+  // Cannot delete the payment request if we already have transactions
+  const disableDeleteButton = await hasTransactions(requestId);
 
   return (
     <>
@@ -49,11 +77,27 @@ export const RequestDetails = async ({ requestId }: { requestId: string }) => {
         }}
       >
         <h2 className="govie-heading-m">{tSetup("details")}</h2>
-        <Link href={`/paymentSetup/edit/${requestId}`}>
-          <button className="govie-button govie-button--primary">
-            {tCommon("edit")}
-          </button>
-        </Link>
+        <div
+          style={{
+            display: "flex",
+            gap: "1rem",
+          }}
+        >
+          <Link href={`/paymentSetup/edit/${requestId}`}>
+            <button className="govie-button govie-button--primary">
+              {tCommon("edit")}
+            </button>
+          </Link>
+          <form action={deletePR}>
+            <button
+              className="govie-button govie-button--tertiary"
+              // I'd like to add a tooltip here to explain why the button is disabled, but tooltips are not working for me
+              disabled={disableDeleteButton}
+            >
+              {tCommon("delete")}
+            </button>
+          </form>
+        </div>
       </div>
 
       <dl className="govie-summary-list">

--- a/apps/payments/app/[locale]/(hosted)/paymentSetup/requests/[requestId]/page.tsx
+++ b/apps/payments/app/[locale]/(hosted)/paymentSetup/requests/[requestId]/page.tsx
@@ -11,6 +11,7 @@ import dayjs from "dayjs";
 import Link from "next/link";
 import CopyLink from "./CopyBtn";
 import { PgSessions } from "auth/sessions";
+import Tooltip from "../../../../../components/Tooltip";
 
 async function createTransaction(requestId: string, formData: FormData) {
   "use server";
@@ -88,15 +89,22 @@ export const RequestDetails = async ({ requestId }: { requestId: string }) => {
               {tCommon("edit")}
             </button>
           </Link>
-          <form action={deletePR}>
-            <button
-              className="govie-button govie-button--tertiary"
-              // I'd like to add a tooltip here to explain why the button is disabled, but tooltips are not working for me
-              disabled={disableDeleteButton}
+          {disableDeleteButton ? (
+            <Tooltip
+              text={tSetup("Request.actions.delete.cannotDelete")}
+              width="300px"
             >
-              {tCommon("delete")}
-            </button>
-          </form>
+              <button className="govie-button govie-button--tertiary" disabled>
+                {tCommon("delete")}
+              </button>
+            </Tooltip>
+          ) : (
+            <form action={deletePR}>
+              <button className="govie-button govie-button--tertiary">
+                {tCommon("delete")}
+              </button>
+            </form>
+          )}
         </div>
       </div>
 

--- a/apps/payments/app/components/Tooltip.tsx
+++ b/apps/payments/app/components/Tooltip.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useState, useRef } from "react";
+
+export default function Tooltip({ children, text, position = "top", width }) {
+  const [isVisible, setIsVisible] = useState(false);
+  const tooltipRef = useRef(null);
+
+  const showTooltip = () => setIsVisible(true);
+  const hideTooltip = () => setIsVisible(false);
+
+  const getTooltipStyle = () => {
+    switch (position) {
+      case "bottom":
+        return {
+          top: "100%",
+          left: "50%",
+          transform: "translateX(-50%)",
+          marginTop: "8px",
+        };
+      case "left":
+        return {
+          right: "100%",
+          top: "50%",
+          transform: "translateY(-50%)",
+          marginRight: "8px",
+        };
+      case "right":
+        return {
+          left: "100%",
+          top: "50%",
+          transform: "translateY(-50%)",
+          marginLeft: "8px",
+        };
+      case "top":
+      default:
+        return {
+          bottom: "100%",
+          left: "50%",
+          transform: "translateX(-50%)",
+          marginBottom: "8px",
+        };
+    }
+  };
+
+  return (
+    <div style={{ position: "relative", display: "inline-block" }}>
+      {isVisible && (
+        <div
+          ref={tooltipRef}
+          style={{
+            position: "absolute",
+            padding: "5px",
+            backgroundColor: "black",
+            borderRadius: "4px",
+            textAlign: "center",
+            zIndex: 1000,
+            color: "white",
+            ...getTooltipStyle(),
+            width,
+          }}
+        >
+          <p className="govie-body" style={{ color: "white" }}>
+            {text}
+          </p>
+        </div>
+      )}
+      <div
+        onMouseEnter={showTooltip}
+        onMouseLeave={hideTooltip}
+        onFocus={showTooltip}
+        onBlur={hideTooltip}
+        tabIndex={0}
+      >
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/payments/messages/en.json
+++ b/apps/payments/messages/en.json
@@ -123,7 +123,12 @@
       "assignDescription": "Send this payment to a user",
       "userPpsn": "User PPS Number",
       "userPpsnHint": "The Personal Public Service Number of the user you would like to assign this payment to",
-      "confirm": "Confirm"
+      "confirm": "Confirm",
+      "actions": {
+        "delete": {
+          "cannotDelete": "Cannot delete payment request since there are existing transactions"
+        }
+      }
     },
     "CreatePayment": {
       "title": "Payment Setup Form",

--- a/apps/payments/messages/en.json
+++ b/apps/payments/messages/en.json
@@ -3,7 +3,8 @@
     "notFound": "Payment request not found",
     "edit": "Edit",
     "save": "Save",
-    "currencySymbol": "€"
+    "currencySymbol": "€",
+    "delete": "Delete"
   },
   "PaymentSetup": {
     "menu": {


### PR DESCRIPTION
- Add "Delete" button on the payment request
- A payment request can be deleted only if there are no transactions yet
- An use case can be experimenting with the system, creating a Draft payment request or just creating it by mistake
- If there are already payment requests, the Payment request can only be "Disabled" in order to not accept new transactions (will be implemented in a new PR)