### PR TITLE
Build Stripe instance at runtime

### DIFF
--- a/apps/payments/app/integration/stripe.ts
+++ b/apps/payments/app/integration/stripe.ts
@@ -1,17 +1,19 @@
 import s from "stripe";
 
-const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY;
-if (!STRIPE_SECRET_KEY) throw new Error("Stripe secret key not found");
+const getStripeInstance = () => {
+  const STRIPE_SECRET_KEY = process.env.STRIPE_SECRET_KEY;
+  if (!STRIPE_SECRET_KEY) throw new Error("Stripe secret key not found");
 
-const stripe = new s(STRIPE_SECRET_KEY);
+  return new s(STRIPE_SECRET_KEY);
+};
 
 export async function createPaymentIntent(paymentRequest) {
-  return await stripe.paymentIntents.create({
+  return await getStripeInstance().paymentIntents.create({
     amount: paymentRequest.amount,
     currency: "GBP",
   });
 }
 
 export async function getPaymentIntent(clientSecret) {
-  return await stripe.paymentIntents.retrieve(clientSecret);
+  return await getStripeInstance().paymentIntents.retrieve(clientSecret);
 }


### PR DESCRIPTION
Right now, if I don't have the `STRIPE_SECRET_KEY` created, even if I use TrueLayer the code explodes since it requires the variable to be set when we import the module.

By creating the Stripe instance only when needed, we fix this env variable check