### PR TITLE
Revert cors config

### DIFF
--- a/apps/mock-api/src/index.js
+++ b/apps/mock-api/src/index.js
@@ -76,14 +76,7 @@ fastify.register(autoload, {
 });
 
 await fastify.register(cors, {
-  origin: (origin, callback) => {
-    const hostname = new URL(origin).hostname;
-    if (origin === fastify.config.ORIGIN_URL || hostname === "localhost") {
-      callback(null, true);
-    } else {
-      callback(new Error("CORS Error: Origin not allowed"), false);
-    }
-  },
+  origin: fastify.config.ORIGIN_URL,
 });
 
 try {


### PR DESCRIPTION
### Description

This is to revert the cors config to how it was before the [timeline pr](https://github.com/ogcio/life-events/pull/63) as the login redirect we do is not working with this setup. Will further investigate it on Monday.

## Type

- [ ] **Dependency upgrade**
- [ ] **Bug fix**
- [ ] **New feature**
- [ ] **Dev change**

### Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works

### Screenshots:

N/A
