### PR TITLE
Fix next public api endpoint used by web app

### DIFF
--- a/pipeline-variables/dev.yml
+++ b/pipeline-variables/dev.yml
@@ -4,4 +4,4 @@ variables:
   ecrEndpoint: 730335224023.dkr.ecr.eu-west-1.amazonaws.com
   nextPublicStripePublishableKey: pk_test_51OzFkUK1VL0xyyr2E3EvcEmzsAGLowKH3jlM4g3AhQwUjhlpxQvfjZizc5GRSAnNzf8HHwTdzhz2rRYS69nooxtg00ZF7kRvyN
   nextPublicHostUrl: https://payments.dev.blocks.gov.ie/
-  nextPublicApiEndpoint: https://api.dev.blocks.gov.ie/
+  nextPublicApiEndpoint: https://api.dev.blocks.gov.ie


### PR DESCRIPTION
### Description

Removing final slash on the `nextPublicApiEndpoint` used on timeline client components.

## Type

- [ ] **Dependency upgrade**
- [ ] **Bug fix**
- [ ] **New feature**
- [ ] **Dev change**

### Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works

### Screenshots:

N/A
