### PR TITLE
Extra pipeline task to force the deployment of new container

### DIFF
--- a/azure_pipelines.yml
+++ b/azure_pipelines.yml
@@ -2,7 +2,6 @@ trigger:
   - dev
   - uat
   - sta
-  - feat/improve-pipeline
 
 pr:
   branches:
@@ -149,3 +148,10 @@ stages:
             sourceImageTag: $(Build.BuildId)
             pushTag: $(Build.SourceBranchName)
             repositoryName: life-events-${{ serviceName }}
+        - task: AWSCLI@1
+          inputs:
+            awsCredentials: $(awsServiceConnection)
+            regionName: $(awsRegion)
+            awsCommand: 'ecs'
+            awsSubCommand: 'update-service'
+            awsArguments: '--force-new-deployment --cluster life-events-ecs --service ${{ serviceName }}-service'


### PR DESCRIPTION
Added task at the end of the pipeline to force ECS to redeploy each service, forcing it to download and run the newly sent images
