### PR TITLE
Small fix to prevent create button on sms provider if provider was never selected

### DIFF
--- a/apps/messaging/app/[locale]/admin/settings/sms/provider/page.tsx
+++ b/apps/messaging/app/[locale]/admin/settings/sms/provider/page.tsx
@@ -279,9 +279,11 @@ export default async (props: { searchParams?: { id: string } }) => {
             </FormElement>
           </>
         ) : null}
-        <button className="govie-button">
-          {props.searchParams?.id ? t("submitUpdate") : t("submitCreate")}
-        </button>
+        {state ?? data?.config.type ? (
+          <button className="govie-button">
+            {props.searchParams?.id ? t("submitUpdate") : t("submitCreate")}
+          </button>
+        ) : null}
       </form>
       <Link href="/admin/settings/sms" className="govie-back-link">
         {t("backLink")}


### PR DESCRIPTION
### Ticket:
-
### Description

Simple if/else to hide the button if no provider was ever saved to state.

## Type

- [ ] **Dependency upgrade**
- [ ] **Bug fix**
- [ ] **New feature**
- [x] **Dev change**

### Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works

### Screenshots:

N/A
