### PR TITLE
feat(dockerfile) Added dockerfile to run timeline on plain nodejs

### DIFF
--- a/apps/timeline-api/.eslintrc.json
+++ b/apps/timeline-api/.eslintrc.json
@@ -1,18 +1,18 @@
 {
-    "parser": "@typescript-eslint/parser",
-    "extends": [
-      "plugin:@typescript-eslint/recommended",
-      "plugin:prettier/recommended",
-      "eslint:recommended"
-    ],
-    "parserOptions": {
-      "ecmaVersion": 2020,
-      "sourceType": "module"
-    },
-    "rules": {
-    },
-    "env": {
-      "browser": true,
-      "node": true
-    }
-  }
+  "parser": "@typescript-eslint/parser",
+  "extends": [
+    "plugin:@typescript-eslint/recommended",
+    "plugin:prettier/recommended",
+    "eslint:recommended"
+  ],
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module"
+  },
+  "rules": {},
+  "env": {
+    "browser": true,
+    "node": true
+  },
+  "ignorePatterns": ["dist"]
+}

--- a/apps/timeline-api/Dockerfile
+++ b/apps/timeline-api/Dockerfile
@@ -3,10 +3,13 @@ FROM base-deps as deps
 WORKDIR /app
 
 COPY ./package*.json /app/
-COPY ./apps/timeline-api/ /app/apps/timeline-api/
+COPY ./apps/timeline-api/ /app/apps/timeline-api/ 
 COPY ./packages/logging-wrapper/ /app/packages/logging-wrapper/
 COPY ./packages/error-handler/ /app/packages/error-handler/
 RUN npm ci
+
+
+FROM deps AS builder
 
 WORKDIR /app/packages/logging-wrapper/
 RUN npm run build
@@ -14,12 +17,32 @@ RUN npm run build
 WORKDIR /app/packages/error-handler/
 RUN npm run build
 
-FROM deps AS builder
+WORKDIR /app/apps/timeline-api/
+RUN npm run build
+
+FROM base-deps AS runner
 WORKDIR /app
+
+
+COPY --from=builder /app/package*.json /app/
+
+COPY --from=builder /app/apps/timeline-api/dist /app/apps/timeline-api/dist
+COPY --from=builder /app/apps/timeline-api/package*.json /app/apps/timeline-api/.env /app/apps/timeline-api/
+
+COPY --from=builder /app/packages/logging-wrapper/dist /app/packages/logging-wrapper/dist
+COPY --from=builder /app/packages/logging-wrapper/package.json /app/packages/logging-wrapper/
+
+COPY --from=builder /app/packages/error-handler/dist /app/packages/error-handler/dist
+COPY --from=builder /app/packages/error-handler/package.json /app/packages/error-handler/
+
 
 ENV NODE_ENV=production
 ENV LOG_LEVEL=trace
+RUN npm ci
+
 
 EXPOSE 8004
 
-CMD [ "npm", "--prefix", "apps/timeline-api",  "run", "dev" ]
+WORKDIR /app/apps/timeline-api
+
+CMD [ "node", "dist/", "index.js" ]

--- a/apps/timeline-api/Dockerfile
+++ b/apps/timeline-api/Dockerfile
@@ -27,18 +27,22 @@ WORKDIR /app
 COPY --from=builder /app/package*.json /app/
 
 COPY --from=builder /app/apps/timeline-api/dist /app/apps/timeline-api/dist
-COPY --from=builder /app/apps/timeline-api/package*.json /app/apps/timeline-api/.env /app/apps/timeline-api/
+COPY --from=builder /app/apps/timeline-api/node_modules /app/apps/timeline-api/node_modules
+COPY --from=builder /app/apps/timeline-api/package*.json /app/apps/timeline-api/
 
 COPY --from=builder /app/packages/logging-wrapper/dist /app/packages/logging-wrapper/dist
+COPY --from=builder /app/packages/logging-wrapper/node_modules /app/packages/logging-wrapper/node_modules
 COPY --from=builder /app/packages/logging-wrapper/package.json /app/packages/logging-wrapper/
 
 COPY --from=builder /app/packages/error-handler/dist /app/packages/error-handler/dist
+COPY --from=builder /app/packages/error-handler/node_modules /app/packages/error-handler/node_modules
 COPY --from=builder /app/packages/error-handler/package.json /app/packages/error-handler/
 
 
 ENV NODE_ENV=production
 ENV LOG_LEVEL=trace
-RUN npm ci
+
+RUN npm prune --omit=dev
 
 
 EXPOSE 8004

--- a/apps/timeline-api/app.ts
+++ b/apps/timeline-api/app.ts
@@ -1,20 +1,20 @@
 import fastify, { FastifyServerOptions } from "fastify";
-import routes from "./routes";
+import routes from "./routes/index.js";
 import fastifyEnv from "@fastify/env";
 import { TypeBoxTypeProvider } from "@fastify/type-provider-typebox";
 import dotenv from "dotenv";
-import { envSchema } from "./config";
-import authPlugin from "./plugins/auth";
+import { envSchema } from "./config.js";
+import authPlugin from "./plugins/auth.js";
 import fastifySwagger from "@fastify/swagger";
 import fastifySwaggerUi from "@fastify/swagger-ui";
 import fs from "fs";
 import { fileURLToPath } from "url";
 import { dirname, join } from "path";
-import healthCheck from "./routes/healthcheck";
+import healthCheck from "./routes/healthcheck.js";
 import sensible from "@fastify/sensible";
 import postgres from "@fastify/postgres";
-import { initializeErrorHandler } from "error-handler";
 import { initializeLoggingHooks } from "logging-wrapper";
+import { initializeErrorHandler } from "error-handler";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);

--- a/apps/timeline-api/index.ts
+++ b/apps/timeline-api/index.ts
@@ -1,6 +1,6 @@
 import { writeFile } from "fs/promises";
 
-import { build } from "./app";
+import { build } from "./app.js";
 import { getLoggingConfiguration } from "logging-wrapper";
 
 const app = await build(getLoggingConfiguration());

--- a/apps/timeline-api/package.json
+++ b/apps/timeline-api/package.json
@@ -2,13 +2,14 @@
   "name": "timeline-api",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "dist/index.js",
   "scripts": {
     "test": "node --import=tsx --test ./test/*.ts",
-    "start": "node --import tsx index.ts",
+    "start": "node dist/index.js",
     "dev": "nodemon | pino-pretty",
     "lint": "eslint . --ext .ts",
-    "generate-ts-client": "npx openapi-typescript ./openapi-definition.yml -o ../../packages/building-blocks-sdk/services/timeline/schema.d.ts"
+    "generate-ts-client": "npx openapi-typescript ./openapi-definition.yml -o ../../packages/building-blocks-sdk/services/timeline/schema.d.ts",
+    "build": "rm -rf dist && tsc -p tsconfig.prod.json && cp logo.png dist/"
   },
   "nodemonConfig": {
     "watch": [
@@ -40,8 +41,6 @@
     "dotenv": "^16.4.5",
     "fastify": "^4.26.2",
     "fastify-plugin": "^4.5.1",
-    "logging-wrapper": "*",
-    "error-handler": "*",
     "pg": "^8.11.3"
   },
   "devDependencies": {
@@ -52,11 +51,11 @@
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.1.3",
+    "openapi-typescript": "^6.7.5",
     "pino-pretty": "^11.0.0",
     "prettier": "^3.2.5",
     "ts-node": "^10.9.2",
     "tsx": "^4.7.1",
-    "typescript": "^5.4.2",
-    "openapi-typescript": "^6.7.5"
+    "typescript": "^5.4.2"
   }
 }

--- a/apps/timeline-api/routes/index.ts
+++ b/apps/timeline-api/routes/index.ts
@@ -1,5 +1,5 @@
 import { FastifyInstance } from "fastify";
-import timeline from "./timeline";
+import timeline from "./timeline/index.js";
 
 export default async function routes(app: FastifyInstance) {
   app.register(timeline, { prefix: "/timeline" });

--- a/apps/timeline-api/routes/timeline/index.ts
+++ b/apps/timeline-api/routes/timeline/index.ts
@@ -1,10 +1,10 @@
 import { FastifyInstance } from "fastify";
-import { HttpError } from "../../types/httpErrors";
+import { HttpError } from "../../types/httpErrors.js";
 import {
   Event,
   GetTimelineData,
   TimelineData,
-} from "../../types/schemaDefinitions";
+} from "../../types/schemaDefinitions.js";
 
 const drivingEvent1 = (date: string | number | Date) => ({
   service: "driving",

--- a/apps/timeline-api/test/healthcheck.test.ts
+++ b/apps/timeline-api/test/healthcheck.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert";
-import { build } from "../app";
+import { build } from "../app.js";
 
 test("healthCheck", async (t) => {
   const app = await build();

--- a/apps/timeline-api/tsconfig.json
+++ b/apps/timeline-api/tsconfig.json
@@ -1,14 +1,13 @@
 {
   "compilerOptions": {
-    "target": "es2022",
-    "module": "ES2022",
-    "moduleResolution": "Node",
+    "target": "ESNext",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,
-    "typeRoots": [
-      "types"
-    ]
+    "typeRoots": ["types"],
+    "outDir": "dist"
   }
 }

--- a/apps/timeline-api/tsconfig.prod.json
+++ b/apps/timeline-api/tsconfig.prod.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig",
+  "exclude": ["test"]
+}

--- a/apps/web/app/[locale]/timeline/page.tsx
+++ b/apps/web/app/[locale]/timeline/page.tsx
@@ -29,6 +29,7 @@ export default async (props: web.NextPageProps) => {
     Object.fromEntries(queryParams),
   );
   // HANDLE ERROR
+
   const responseData = timelineResponse.data;
 
   return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -65,8 +65,10 @@
         "auth": "*",
         "aws-sdk": "^2.1604.0",
         "dotenv": "^16.4.5",
+        "error-handler": "*",
         "fastify": "^4.26.2",
         "fastify-plugin": "^4.5.1",
+        "logging-wrapper": "*",
         "nodemailer": "^6.9.13",
         "pg": "^8.11.3"
       },
@@ -708,8 +710,10 @@
         "@sinclair/typebox": "^0.32.16",
         "auth": "*",
         "dotenv": "^16.4.5",
+        "error-handler": "*",
         "fastify": "^4.26.2",
         "fastify-plugin": "^4.5.1",
+        "logging-wrapper": "*",
         "pg": "^8.11.3"
       },
       "devDependencies": {
@@ -19409,8 +19413,7 @@
       "license": "ISC",
       "dependencies": {
         "@fastify/error": "^3.4.1",
-        "fastify": "^4.26.2",
-        "logging-wrapper": "*"
+        "fastify": "^4.26.2"
       },
       "devDependencies": {
         "@tsconfig/node20": "^20.1.4",

--- a/packages/error-handler/.eslintrc.json
+++ b/packages/error-handler/.eslintrc.json
@@ -22,5 +22,6 @@
   },
   "env": {
     "node": true
-  }
+  },
+  "ignorePatterns": ["dist"]
 }

--- a/packages/error-handler/__tests__/helpers/build-fastify.ts
+++ b/packages/error-handler/__tests__/helpers/build-fastify.ts
@@ -1,7 +1,7 @@
 import { FastifyError, createError } from "@fastify/error";
 import { pino, DestinationStream } from "pino";
 import fastify, { FastifyInstance } from "fastify";
-import { initializeErrorHandler } from "../..";
+import { initializeErrorHandler } from "../../src/index.js";
 
 export const buildFastify = (
   loggerDestination?: DestinationStream,

--- a/packages/error-handler/__tests__/helpers/fastify-test-helpers.ts
+++ b/packages/error-handler/__tests__/helpers/fastify-test-helpers.ts
@@ -1,5 +1,5 @@
 import { FastifyInstance } from "fastify";
-import { buildFastify } from "./build-fastify";
+import { buildFastify } from "./build-fastify.js";
 export const DEFAULT_HOSTNAME = "localhost:80";
 export const DEFAULT_USER_AGENT = "lightMyRequest";
 export const DEFAULT_REQUEST_HEADERS = {

--- a/packages/error-handler/__tests__/initialize-error-handler.test.ts
+++ b/packages/error-handler/__tests__/initialize-error-handler.test.ts
@@ -3,7 +3,7 @@ import {
   DEFAULT_METHOD,
   DEFAULT_PATH,
   initializeServer,
-} from "./helpers/fastify-test-helpers";
+} from "./helpers/fastify-test-helpers.js";
 
 t.test("Common error is managed as expected", async () => {
   const { server } = initializeServer();

--- a/packages/error-handler/package.json
+++ b/packages/error-handler/package.json
@@ -6,6 +6,7 @@
   "files": ["dist"],
   "type": "module",
   "scripts": {
+    "dev": "rm -rf dist && tsc -w -p tsconfig.prod.json",
     "test": "TAP_RCFILE=tap.yml tap",
     "build": "rm -rf dist && tsc -p tsconfig.prod.json",
     "lint": "eslint . --ext .ts",

--- a/packages/error-handler/package.json
+++ b/packages/error-handler/package.json
@@ -3,19 +3,21 @@
   "version": "0.0.1",
   "description": "",
   "main": "dist/index.js",
+  "files": ["dist"],
+  "type": "module",
   "scripts": {
     "test": "TAP_RCFILE=tap.yml tap",
-    "build": "tsc -p tsconfig.json",
+    "build": "rm -rf dist && tsc -p tsconfig.prod.json",
     "lint": "eslint . --ext .ts",
-    "lint:fix": "eslint . --ext .ts --fix"
+    "lint:fix": "eslint . --ext .ts --fix",
+    "list": "tsc --listFiles"
   },
   "keywords": [],
   "author": "samuele.salvatico@nearform.com",
   "license": "ISC",
   "dependencies": {
     "@fastify/error": "^3.4.1",
-    "fastify": "^4.26.2",
-    "logging-wrapper": "*"
+    "fastify": "^4.26.2"
   },
   "devDependencies": {
     "@tsconfig/node20": "^20.1.4",

--- a/packages/error-handler/src/index.ts
+++ b/packages/error-handler/src/index.ts
@@ -2,7 +2,7 @@ import { FastifyInstance } from "fastify";
 import {
   initializeNotFoundHandler,
   setupErrorHandler,
-} from "./src/initialize-error-handler";
+} from "./initialize-error-handler.js";
 
 export const initializeErrorHandler = (server: FastifyInstance): void => {
   setupErrorHandler(server);

--- a/packages/error-handler/src/initialize-error-handler.ts
+++ b/packages/error-handler/src/initialize-error-handler.ts
@@ -9,8 +9,8 @@ import {
   parseErrorClass,
   setLoggingContext,
   getLoggingContextError,
-} from "logging-wrapper/src/logging-wrapper";
-import { LogMessages } from "logging-wrapper/src/logging-wrapper-entities";
+} from "logging-wrapper/dist/logging-wrapper.js";
+import { LogMessages } from "logging-wrapper/dist/logging-wrapper-entities.js";
 
 const buildErrorResponse = (error: FastifyError, request: FastifyRequest) => ({
   code: parseErrorClass(error),

--- a/packages/error-handler/tsconfig.json
+++ b/packages/error-handler/tsconfig.json
@@ -1,11 +1,13 @@
 {
   "compilerOptions": {
-    "target": "ES2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "module": "commonjs",                                /* Specify what module code is generated. */
-    "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
-    "strict": true,                                      /* Enable all strict type-checking options. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "target": "ESNext" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "module": "NodeNext" /* Specify what module code is generated. */,
+    "moduleResolution": "NodeNext",
+    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+    "strict": true /* Enable all strict type-checking options. */,
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */,
+    "declaration": true
   }
 }

--- a/packages/error-handler/tsconfig.prod.json
+++ b/packages/error-handler/tsconfig.prod.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["__tests__"]
+}

--- a/packages/error-handler/tsconfig.prod.json
+++ b/packages/error-handler/tsconfig.prod.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["__tests__"]
+  "exclude": ["__tests__", "dist"]
 }

--- a/packages/logging-wrapper/.eslintrc.json
+++ b/packages/logging-wrapper/.eslintrc.json
@@ -22,5 +22,6 @@
   },
   "env": {
     "node": true
-  }
+  },
+  "ignorePatterns": ["dist"]
 }

--- a/packages/logging-wrapper/__tests__/fastify-logging-wrapper.errors.test.ts
+++ b/packages/logging-wrapper/__tests__/fastify-logging-wrapper.errors.test.ts
@@ -1,6 +1,9 @@
-import { LogErrorClasses } from "../src/logging-wrapper-entities";
+import { LogErrorClasses } from "../src/logging-wrapper-entities.js";
 import { t } from "tap";
-import { initializeServer, runErrorTest } from "./helpers/fastify-test-helpers";
+import {
+  initializeServer,
+  runErrorTest,
+} from "./helpers/fastify-test-helpers.js";
 
 t.test("Error data are correctly set", async () => {
   const { server, loggingDestination } = initializeServer();

--- a/packages/logging-wrapper/__tests__/fastify-logging-wrapper.test.ts
+++ b/packages/logging-wrapper/__tests__/fastify-logging-wrapper.test.ts
@@ -1,4 +1,4 @@
-import { LogMessages } from "../src/logging-wrapper-entities";
+import { LogMessages } from "../src/logging-wrapper-entities.js";
 import { t } from "tap";
 import {
   initializeServer,
@@ -8,7 +8,7 @@ import {
   checkExpectedResponseEntry,
   parseLogEntry,
   checkGenericEntryFields,
-} from "./helpers/fastify-test-helpers";
+} from "./helpers/fastify-test-helpers.js";
 
 t.test(
   "Logging entries when all works fine are the expected ones",

--- a/packages/logging-wrapper/__tests__/helpers/build-fastify.ts
+++ b/packages/logging-wrapper/__tests__/helpers/build-fastify.ts
@@ -2,7 +2,7 @@ import Fastify from "fastify";
 import {
   getLoggingConfiguration,
   initializeLoggingHooks,
-} from "../../src/fastify-logging-wrapper";
+} from "../../src/fastify-logging-wrapper.js";
 import { DestinationStream } from "pino";
 import { createError } from "@fastify/error";
 

--- a/packages/logging-wrapper/__tests__/helpers/build-logger.ts
+++ b/packages/logging-wrapper/__tests__/helpers/build-logger.ts
@@ -1,4 +1,4 @@
-import { PinoLoggerOptions } from "fastify/types/logger";
+import { PinoLoggerOptions } from "fastify/types/logger.js";
 import { pino } from "pino";
 
 export const buildLogger = (loggerConfiguration: PinoLoggerOptions) => {

--- a/packages/logging-wrapper/__tests__/helpers/fastify-test-helpers.ts
+++ b/packages/logging-wrapper/__tests__/helpers/fastify-test-helpers.ts
@@ -1,13 +1,13 @@
 import { FastifyInstance } from "fastify";
-import { buildFastify } from "./build-fastify";
+import { buildFastify } from "./build-fastify.js";
 import {
   TestingLoggerDestination,
   getTestingDestinationLogger,
-} from "./build-logger";
+} from "./build-logger.js";
 import {
   LogErrorClasses,
   LogMessages,
-} from "../../src/logging-wrapper-entities";
+} from "../../src/logging-wrapper-entities.js";
 import { t } from "tap";
 
 export const DEFAULT_HOSTNAME = "localhost:80";

--- a/packages/logging-wrapper/__tests__/logging-wrapper.test.ts
+++ b/packages/logging-wrapper/__tests__/logging-wrapper.test.ts
@@ -1,9 +1,9 @@
 import t from "tap";
 import { Level } from "pino";
-import { getLoggerConfiguration } from "../src/logging-wrapper";
-import { buildLogger } from "./helpers/build-logger";
+import { getLoggerConfiguration } from "../src/logging-wrapper.js";
+import { buildLogger } from "./helpers/build-logger.js";
 import { hostname } from "os";
-import { REDACTED_VALUE } from "../src/logging-wrapper-entities";
+import { REDACTED_VALUE } from "../src/logging-wrapper-entities.js";
 
 const getRandomFieldValue = (): string => Math.random().toString(36).slice(2);
 

--- a/packages/logging-wrapper/package.json
+++ b/packages/logging-wrapper/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "type": "module",
   "scripts": {
+    "dev": "rm -rf dist && tsc -w -p tsconfig.prod.json",
     "test": "TAP_RCFILE=tap.yml tap",
     "build": "rm -rf dist && tsc -p tsconfig.prod.json",
     "lint": "eslint . --ext .ts",

--- a/packages/logging-wrapper/package.json
+++ b/packages/logging-wrapper/package.json
@@ -3,9 +3,10 @@
   "version": "0.0.1",
   "description": "",
   "main": "dist/index.js",
+  "type": "module",
   "scripts": {
     "test": "TAP_RCFILE=tap.yml tap",
-    "build": "tsc -p tsconfig.json",
+    "build": "rm -rf dist && tsc -p tsconfig.prod.json",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix"
   },

--- a/packages/logging-wrapper/src/fastify-logging-wrapper.ts
+++ b/packages/logging-wrapper/src/fastify-logging-wrapper.ts
@@ -1,6 +1,9 @@
 import { FastifyServerOptions, FastifyInstance } from "fastify";
 import hyperid from "hyperid";
-import { LogMessages, REQUEST_ID_LOG_LABEL } from "./logging-wrapper-entities";
+import {
+  LogMessages,
+  REQUEST_ID_LOG_LABEL,
+} from "./logging-wrapper-entities.js";
 import {
   getLoggerConfiguration,
   getLoggingContextError,
@@ -8,7 +11,7 @@ import {
   parseFullLoggingRequest,
   resetLoggingContext,
   setLoggingContext,
-} from "./logging-wrapper";
+} from "./logging-wrapper.js";
 import { pino, DestinationStream } from "pino";
 
 const hyperidInstance = hyperid({ fixedLength: true, urlSafe: true });

--- a/packages/logging-wrapper/src/index.ts
+++ b/packages/logging-wrapper/src/index.ts
@@ -2,7 +2,7 @@ import { FastifyInstance, FastifyServerOptions } from "fastify";
 import {
   getLoggingConfiguration as fastifyLoggingConfiguration,
   initializeLoggingHooks as fastifyLoggingHooks,
-} from "./src/fastify-logging-wrapper";
+} from "./fastify-logging-wrapper.js";
 import { DestinationStream } from "pino";
 
 export const getLoggingConfiguration = (

--- a/packages/logging-wrapper/src/logging-wrapper.ts
+++ b/packages/logging-wrapper/src/logging-wrapper.ts
@@ -10,8 +10,8 @@ import {
   REDACTED_VALUE,
   REDACTED_PATHS,
   MESSAGE_KEY,
-} from "./logging-wrapper-entities";
-import { LogLevel, PinoLoggerOptions } from "fastify/types/logger";
+} from "./logging-wrapper-entities.js";
+import { LogLevel, PinoLoggerOptions } from "fastify/types/logger.js";
 
 const loggingContext: LoggingContext = {};
 const UNHANDLED_EXCEPTION_CODE = "UNHANDLED_EXCEPTION";

--- a/packages/logging-wrapper/tsconfig.json
+++ b/packages/logging-wrapper/tsconfig.json
@@ -1,11 +1,13 @@
 {
   "compilerOptions": {
-    "target": "ES2022",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    "module": "commonjs",                                /* Specify what module code is generated. */
-    "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
-    "strict": true,                                      /* Enable all strict type-checking options. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "target": "ESNext" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "module": "NodeNext" /* Specify what module code is generated. */,
+    "outDir": "./dist" /* Specify an output folder for all emitted files. */,
+    "moduleResolution": "NodeNext",
+    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
+    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+    "strict": true /* Enable all strict type-checking options. */,
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */,
+    "declaration": true
   }
 }

--- a/packages/logging-wrapper/tsconfig.prod.json
+++ b/packages/logging-wrapper/tsconfig.prod.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig",
-  "exclude": ["__tests__"]
+  "exclude": ["__tests__", "dist"]
 }

--- a/packages/logging-wrapper/tsconfig.prod.json
+++ b/packages/logging-wrapper/tsconfig.prod.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig",
+  "exclude": ["__tests__"]
+}


### PR DESCRIPTION
### Description

Some changes to the code infra

- Changed `timeline-api`, `error-handler`, `logging-wrapper`, to export ESM and work as ESM
- Changed dockerfile for `timeline-api` to run plain nodejs

## Type

- [ ] **Dependency upgrade**
- [ ] **Bug fix**
- [ ] **New feature**
- [x] **Dev change**

