### PR TITLE
Fix: enable public servant

### DIFF
--- a/apps/mock-api/src/stubs/login/index.html
+++ b/apps/mock-api/src/stubs/login/index.html
@@ -226,11 +226,11 @@
       lastName = nameSplit.slice(1).join(" ");
       document.querySelector("input[name='public_servant']").checked =
         user.is_public_servant;
-      document.querySelector("input[name='public_servant']").disabled = true;
+      document.querySelector("input[name='public_servant']").setAttribute('readonly', true);
     } else {
       firstName = faker.person.firstName();
       lastName = faker.person.lastName();
-      document.querySelector("input[name='public_servant']").disabled = false;
+      document.querySelector("input[name='public_servant']").setAttribute('readonly', false);
     }
 
     document.querySelector("#id_token").value = createUnsecuredJwt(

--- a/apps/mock-api/src/stubs/login/index.html
+++ b/apps/mock-api/src/stubs/login/index.html
@@ -188,7 +188,7 @@
 <script type="module">
   import { faker } from "https://esm.sh/@faker-js/faker";
   import * as jose from "https://cdnjs.cloudflare.com/ajax/libs/jose/5.2.2/index.js";
-
+  let isCurrentUserSet = false;
   const returnUrl = new URLSearchParams(window.location.search).get(
     "return_url",
   );
@@ -204,6 +204,7 @@
   ).json();
 
   const usersSelectElement = document.querySelector("#user_select");
+  const publicServantCheckbox = document.querySelector("input[name='public_servant']");
 
   for (const u of apiUsers.users) {
     var option = document.createElement("option");
@@ -214,23 +215,32 @@
     usersSelectElement.add(option);
   }
 
+  publicServantCheckbox.addEventListener("click", (e) => {
+    if(isCurrentUserSet === false) {
+      return;
+    }
+
+    e.preventDefault();
+  });
+
   usersSelectElement.addEventListener("change", (e) => {
     const user = apiUsers.users.find(
       (user) => user.govid_email === e.target.value,
     );
 
     let firstName, lastName;
+    
     if (user) {
       const nameSplit = user.user_name.split(" ");
       firstName = nameSplit.at(0);
       lastName = nameSplit.slice(1).join(" ");
       document.querySelector("input[name='public_servant']").checked =
         user.is_public_servant;
-      document.querySelector("input[name='public_servant']").setAttribute('readonly', true);
+      isCurrentUserSet = true;
     } else {
       firstName = faker.person.firstName();
       lastName = faker.person.lastName();
-      document.querySelector("input[name='public_servant']").setAttribute('readonly', false);
+      isCurrentUserSet = false;
     }
 
     document.querySelector("#id_token").value = createUnsecuredJwt(


### PR DESCRIPTION
### Description

Before, in the login page, we used to disable the public servant checkbox when a public servant from the list was selected.
Because of this (the fact that the input is disabled), the value of the checkbox was not passed to the form submission, causing the user to login not as public servant.
Now we just prevent changing the value of the checkbox if the user is chosen from the dropdown

## Type

- [ ] **Dependency upgrade**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Dev change**