### PR TITLE
Remove deprecated messages table trail in migrations

### DIFF
--- a/packages/messages/migrations/sqls/20240306163250-init-up.sql
+++ b/packages/messages/migrations/sqls/20240306163250-init-up.sql
@@ -15,18 +15,6 @@ CREATE TABLE email_template_translations (
 
 CREATE TYPE language_enum AS ENUM ('EN', 'GA');
 
-
-CREATE TABLE messages (
-    id UUID NOT NULL DEFAULT gen_random_uuid(),
-    fromEmail TEXT NOT NULL,
-    toEmail TEXT NOT NULL,
-    subject TEXT NOT NULL,
-    body TEXT NOT NULL,
-    status TEXT NOT NULL,
-    workflow_id TEXT NOT NULL,
-    PRIMARY KEY (id)
-);
-
 CREATE TABLE notifications (
     id UUID NOT NULL DEFAULT gen_random_uuid(),
     subject TEXT NOT NULL,

--- a/packages/messages/migrations/sqls/20240318121837-simplication-poc-down.sql
+++ b/packages/messages/migrations/sqls/20240318121837-simplication-poc-down.sql
@@ -2,20 +2,9 @@
 
   DROP TABLE message_states;
 
-  DROP TABLE messages;
-
   DROP TABLE message_interpolation_accessors;
 
-CREATE TABLE messages (
-    id UUID NOT NULL DEFAULT gen_random_uuid(),
-    fromEmail TEXT NOT NULL,
-    toEmail TEXT NOT NULL,
-    subject TEXT NOT NULL,
-    body TEXT NOT NULL,
-    status TEXT NOT NULL,
-    workflow_id TEXT NOT NULL,
-    PRIMARY KEY (id)
-);
+
 
 CREATE TABLE notifications (
     id UUID NOT NULL DEFAULT gen_random_uuid(),

--- a/packages/messages/migrations/sqls/20240318121837-simplication-poc-up.sql
+++ b/packages/messages/migrations/sqls/20240318121837-simplication-poc-up.sql
@@ -1,5 +1,4 @@
 DROP TABLE notifications;
-  DROP TABLE messages;
 
   CREATE TABLE IF NOT EXISTS form_errors(
     user_id UUID NOT NULL,
@@ -13,18 +12,6 @@ DROP TABLE notifications;
     state_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     user_id UUID NOT NULL,
     state JSONB
-  );
-
-  CREATE TABLE IF NOT EXISTS messages (
-    message_id uuid default gen_random_uuid(),
-    for_email text not null,
-    subject text not null,
-    abstract text,
-    content text,
-    action_url text,
-    is_unseen boolean default true,
-    message_type text not null,
-    created_at timestamptz default now()
   );
 
   create table message_interpolation_accessors(

--- a/packages/messages/migrations/sqls/20240327111420-payment-integration-down.sql
+++ b/packages/messages/migrations/sqls/20240327111420-payment-integration-down.sql
@@ -1,4 +1,3 @@
 /* Replace with your SQL commands */
 
-ALTER TABLE messages DROP COLUMN payment_request_id;
-ALTER TABLE messages DROP COLUMN payment_user_id;
+

--- a/packages/messages/migrations/sqls/20240327111420-payment-integration-up.sql
+++ b/packages/messages/migrations/sqls/20240327111420-payment-integration-up.sql
@@ -1,4 +1,3 @@
 /* Replace with your SQL commands */
 
-ALTER TABLE messages ADD COLUMN payment_request_id uuid;
-ALTER TABLE messages ADD COLUMN payment_user_id uuid;
+

--- a/packages/messages/migrations/sqls/20240408095916-message-model-update-up.sql
+++ b/packages/messages/migrations/sqls/20240408095916-message-model-update-up.sql
@@ -1,6 +1,5 @@
 /* Replace with your SQL commands */
 
-drop table messages;
 drop table email_template_translations;
 drop table email_templates;
 


### PR DESCRIPTION
### Ticket:

- [16950](https://dev.azure.com/OGCIO-Digital-Services/Digital%20Services%20Programme/_workitems/edit/16950)

### Description

Remove the deprecated messages table migrations since there are three of them. 

Only the latest is relevant, thus we don't need a trail of conceptual tables with dropping in the up.

## Type

- [ ] **Dependency upgrade**
- [ ] **Bug fix**
- [ ] **New feature**
- [ ] **Dev change**

### Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works

### Screenshots:

N/A
