### PR TITLE
[Payments] Display error to citizen when accessing inactive payment request

### DIFF
--- a/apps/payments/app/[locale]/(embedded)/paymentRequest/pay/page.tsx
+++ b/apps/payments/app/[locale]/(embedded)/paymentRequest/pay/page.tsx
@@ -79,10 +79,6 @@ export default async function Page(props: Props) {
 
   if (!details) return notFound();
 
-  if (!details.providers.length) {
-    return <h1 className="govie-heading-l">{t("errorNotReady")}</h1>;
-  }
-
   const allowCustomAmount = details.allowCustomAmount;
 
   const urlAmount = props.searchParams.amount


### PR DESCRIPTION
### Ticket:

- [17062](https://dev.azure.com/OGCIO-Digital-Services/Digital%20Services%20Programme/_workitems/edit/17062)

### Description

<!-- Please include a summary of the changes and the related issue. -->
Remove informative message for payment requests without any payment provider. This way citizens will always see a treated error when trying to pay with an inactive payment request. In the near future we'll remove the possibility to have an active payment request with no providers, so we won't need the just removed message anyways

## Type

- [ ] **Dependency upgrade**
- [ ] **Bug fix**
- [x] **New feature**
- [ ] **Dev change**

### Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This change might impact the developer experience of others and should be communicated

### Screenshots:
![Screenshot 2024-05-24 at 09 03 33](https://github.com/ogcio/life-events/assets/47299026/7b23084e-d284-42f7-8038-d89e0c13d465)


