### PR TITLE
chore(Auth) prefill email actual email for migrated users

### DIFF
--- a/apps/mock-api/src/stubs/login/api/index.js
+++ b/apps/mock-api/src/stubs/login/api/index.js
@@ -21,6 +21,7 @@ export default async function (app, opts) {
       public_servant,
       firstName,
       lastName,
+      email,
       redirect_url,
       verificationLevel,
     } = request.body;
@@ -31,8 +32,6 @@ export default async function (app, opts) {
     }
 
     const verificationLevelNumber = Number(verificationLevel);
-
-    const email = `${firstName}.${lastName}@mail.ie`;
 
     const createUnsecuredJwt = (firstName, lastName, email) => {
       // Based on the govid jwt token, filled with some random data

--- a/apps/mock-api/src/stubs/login/index.html
+++ b/apps/mock-api/src/stubs/login/index.html
@@ -105,6 +105,7 @@
           readonly
         />
         <input id="lastName" type="hidden" name="lastName" value="" readonly />
+        <input id="email" type="hidden" name="email" value="" readonly />
         <input
           id="redirect_url"
           type="hidden"
@@ -250,33 +251,37 @@
       (user) => user.govid_email === e.target.value,
     );
 
-    let firstName, lastName;
+    let firstName, lastName, email;
 
     if (user) {
       const nameSplit = user.user_name.split(" ");
       firstName = nameSplit.at(0);
       lastName = nameSplit.slice(1).join(" ");
+      email = user.govid_email;
       document.querySelector("input[name='public_servant']").checked =
         user.is_public_servant;
       isCurrentUserSet = true;
     } else {
       firstName = faker.person.firstName();
       lastName = faker.person.lastName();
+      email = `${firstName.toLowerCase()}.${lastName.toLowerCase()}@mail.ie`;
       isCurrentUserSet = false;
     }
 
     document.querySelector("#firstName").value = firstName;
     document.querySelector("#lastName").value = lastName;
-
+    document.querySelector("#email").value = email;
     document.querySelector("#submit_btn").innerHTML =
       `<div style="margin-top: 5px">Login ${firstName} ${lastName} <span class="icon-signin_id_logo"></span></div>`;
   });
 
   const firstName = faker.person.firstName();
   const lastName = faker.person.lastName();
+  const email = `${firstName.toLowerCase()}.${lastName.toLowerCase()}@mail.ie`;
 
   document.querySelector("#firstName").value = firstName;
   document.querySelector("#lastName").value = lastName;
+  document.querySelector("#email").value = email;
 
   document.querySelector("#submit_btn").innerHTML =
     `<div style="margin-top: 5px">Login ${firstName} ${lastName} <span class="icon-signin_id_logo"></span></div>`;


### PR DESCRIPTION
## Description

This change adds email generation to the mocked login html file, it prevents creating twice the same user when logging in with upserted users.

if via a migration we upsert a user like francesco.maid@nearform.com, when we log in with "Francesco Maida", the mock login will add franceso.maida@mail.ie as a new user in the db.

with this change, we will prefile the email value with the actual one present in the db.

## Type

- [ ] **Dependency upgrade**
- [ ] **Bug fix**
- [ ] **New feature**
- [x] **Dev change**

