### PR TITLE
feat(AuthService) redirect to subpath after login

### DIFF
--- a/apps/auth-service/src/routes/auth/callback.ts
+++ b/apps/auth-service/src/routes/auth/callback.ts
@@ -11,8 +11,9 @@ import streamToString from "./utils/streamToString.js";
 import {
   CLIENT_SECRET,
   CODE,
+  REDIRECT_HOST,
+  REDIRECT_PATH,
   REDIRECT_TIMEOUT,
-  REDIRECT_URL,
   SESSION_ID,
 } from "./utils/replacementConstants.js";
 
@@ -88,8 +89,11 @@ export default async (app: FastifyInstance) => {
 
       const [{ id: ssid }] = query.rows;
 
-      const redirectUrl = request.cookies.redirectUrl || "/auth";
-      deleteCookie(request, reply, "redirectUrl", "");
+      const redirectHost = request.cookies.redirectHost || "/auth";
+      deleteCookie(request, reply, "redirectHost", "");
+
+      const redirectPath = request.cookies.redirectPath || "/";
+      deleteCookie(request, reply, "redirectPath", "");
 
       setCookie(request, reply, "sessionId", ssid);
 
@@ -99,7 +103,8 @@ export default async (app: FastifyInstance) => {
 
       const result = (await streamToString(stream))
         .replace(SESSION_ID, ssid)
-        .replace(REDIRECT_URL, redirectUrl)
+        .replace(REDIRECT_HOST, redirectHost)
+        .replace(REDIRECT_PATH, redirectPath)
         .replaceAll(REDIRECT_TIMEOUT, app.config.REDIRECT_TIMEOUT);
 
       return reply.type("text/html").send(result);

--- a/apps/auth-service/src/routes/auth/index.ts
+++ b/apps/auth-service/src/routes/auth/index.ts
@@ -10,8 +10,9 @@ import streamToString from "./utils/streamToString.js";
 import {
   CALLBACK_URL,
   CLIENT_ID,
+  REDIRECT_HOST,
+  REDIRECT_PATH,
   REDIRECT_TIMEOUT,
-  REDIRECT_URL,
   SESSION_ID,
 } from "./utils/replacementConstants.js";
 
@@ -22,7 +23,8 @@ export default async function login(app: FastifyInstance) {
 
   app.get<{
     Querystring: {
-      redirectUrl: string;
+      redirectHost: string;
+      redirectPath: string;
     };
   }>(
     "/",
@@ -34,7 +36,9 @@ export default async function login(app: FastifyInstance) {
       },
     },
     async (request, reply) => {
-      let redirectUrl = request.query.redirectUrl;
+      let redirectHost = request.query.redirectHost;
+      let redirectPath = request.query.redirectPath;
+
       const sessionId = request.cookies.sessionId;
 
       if (sessionId) {
@@ -50,23 +54,26 @@ export default async function login(app: FastifyInstance) {
           [sessionId],
         );
 
-        if (query.rowCount && redirectUrl) {
+        if (query.rowCount && redirectHost) {
           const stream = fs.createReadStream(
             path.join(__dirname, "..", "static", "redirect.html"),
           );
 
           const result = (await streamToString(stream))
             .replace(SESSION_ID, sessionId)
-            .replace(REDIRECT_URL, redirectUrl)
+            .replace(REDIRECT_HOST, redirectHost)
+            .replace(REDIRECT_PATH, REDIRECT_PATH)
             .replaceAll(REDIRECT_TIMEOUT, app.config.REDIRECT_TIMEOUT);
 
           return reply.type("text/html").send(result);
         }
       }
 
-      redirectUrl = redirectUrl || "/";
+      redirectHost = redirectHost || "/";
+      redirectPath = redirectPath || "/";
 
-      setCookie(request, reply, "redirectUrl", redirectUrl);
+      setCookie(request, reply, "redirectHost", redirectHost);
+      setCookie(request, reply, "redirectPath", redirectPath);
       const authorizeUrl = app.config.MYGOVID_URL.replace(
         CALLBACK_URL,
         app.config.CALLBACK_URL,

--- a/apps/auth-service/src/routes/auth/utils/replacementConstants.ts
+++ b/apps/auth-service/src/routes/auth/utils/replacementConstants.ts
@@ -1,5 +1,6 @@
 export const SESSION_ID = "%SESSION_ID%";
-export const REDIRECT_URL = "%REDIRECT_URL%";
+export const REDIRECT_HOST = "%REDIRECT_HOST%";
+export const REDIRECT_PATH = "%REDIRECT_PATH%";
 export const REDIRECT_TIMEOUT = "%REDIRECT_TIMEOUT%";
 export const CLIENT_ID = "%CLIENT_ID%";
 export const CALLBACK_URL = "%CALLBACK_URL%";

--- a/apps/auth-service/src/routes/static/redirect.html
+++ b/apps/auth-service/src/routes/static/redirect.html
@@ -65,13 +65,22 @@
       class="icon-mygovid_logo"
     ></span>
 
-    <form id="redirect-form" method="POST" action="%REDIRECT_URL%/api/auth">
+    <form
+      id="redirect-form"
+      method="POST"
+      action="%REDIRECT_HOST%/api/auth?redirectPath=%REDIRECT_PATH%"
+    >
       <span
         >You are being redirected back to the application, if redirection does
         not happen within a few seconds,
-        
-        <input type="text" style="display: none;" name="sessionId" value="%SESSION_ID%">
-        
+
+        <input
+          type="text"
+          style="display: none"
+          name="sessionId"
+          value="%SESSION_ID%"
+        />
+
         <button
           type="submit"
           style="
@@ -94,4 +103,5 @@
 <script type="module">
   setTimeout(() => {
     document.querySelector('#redirect-form').submit()
-  }, %REDIRECT_TIMEOUT%)</script>
+  }, %REDIRECT_TIMEOUT%)
+</script>

--- a/packages/auth/src/route.ts
+++ b/packages/auth/src/route.ts
@@ -54,8 +54,8 @@ export default async (req: NextRequest) => {
   if (publicServant) {
     return redirect("/admin", RedirectType.replace);
   }
-  const redirectPath_ = req.nextUrl.searchParams.get("redirectPath");
-  const redirectUrl = redirectPath_ ? `${redirectPath_}` : "/";
+  const redirectPath = req.nextUrl.searchParams.get("redirectPath");
+  const redirectUrl = redirectPath ? `${redirectPath}` : "/";
 
   return redirect(redirectUrl, RedirectType.replace);
 };

--- a/packages/auth/src/route.ts
+++ b/packages/auth/src/route.ts
@@ -1,6 +1,7 @@
 import { cookies } from "next/headers.js";
 import { getPgSession } from "./sessions";
 import { redirect, RedirectType } from "next/navigation.js";
+import { NextRequest } from "next/server";
 
 enum SAME_SITE_VALUES {
   LAX = "lax",
@@ -30,7 +31,7 @@ function getSessionIdCookieConfig(req: Request, cookieValue: string) {
   };
 }
 
-export default async (req: Request) => {
+export default async (req: NextRequest) => {
   const formData = await req.formData();
   const sessionId = formData.get("sessionId")?.toString() ?? "";
 
@@ -41,7 +42,7 @@ export default async (req: Request) => {
     return redirect(loginUrl, RedirectType.replace);
   }
 
-  const session = await getPgSession(sessionId); //PgSessions.get(sessionId);
+  const session = await getPgSession(sessionId);
 
   if (!session) {
     return redirect(loginUrl, RedirectType.replace);
@@ -53,6 +54,8 @@ export default async (req: Request) => {
   if (publicServant) {
     return redirect("/admin", RedirectType.replace);
   }
+  const redirectPath_ = req.nextUrl.searchParams.get("redirectPath");
+  const redirectUrl = redirectPath_ ? `${redirectPath_}` : "/";
 
-  return redirect("/", RedirectType.replace);
+  return redirect(redirectUrl, RedirectType.replace);
 };

--- a/packages/auth/src/sessions.ts
+++ b/packages/auth/src/sessions.ts
@@ -27,7 +27,7 @@ type Session = {
 };
 
 export interface Sessions {
-  get(): Promise<
+  get(redirectUrl?: string): Promise<
     SessionTokenDecoded & {
       userId: string;
       publicServant: boolean;
@@ -126,21 +126,22 @@ export const getSessionData = async (sessionId: string) => {
 };
 
 export const PgSessions: Sessions = {
-  async get() {
+  async get(redirectUrl_) {
     const authServiceUrl = process.env.AUTH_SERVICE_URL;
 
     if (!authServiceUrl) {
       throw Error("Missing env var AUTH_SERVICE_URL");
     }
 
-    const loginUrl = `${authServiceUrl}/auth?redirectUrl=${process.env.HOST_URL}`;
+    const redirectUrl = redirectUrl_ || "/";
+    const loginUrl = `${authServiceUrl}/auth?redirectHost=${process.env.HOST_URL}&redirectPath=${redirectUrl}`;
 
     const sessionId = cookies().get("sessionId")?.value;
     if (!sessionId) {
       return redirect(loginUrl, RedirectType.replace);
     }
 
-    const sessionData = await getSessionData(sessionId); //PgSessions.get(sessionId);
+    const sessionData = await getSessionData(sessionId);
 
     if (!sessionData) {
       return redirect(loginUrl, RedirectType.replace);


### PR DESCRIPTION
### Description

Currently, when users access the app via a subpath such as /timeline without being logged in, they are redirected to the authentication service. After authentication, they are then redirected back to the root level (/) of the app.

With this update, the authentication service will now redirect users back to the specific subpath they originally attempted to access. For example, if a user initially navigates to /timeline, after successful authentication, they will be redirected back to /timeline instead of the root level (/).

## Type

- [ ] **Dependency upgrade**
- [ ] **Bug fix**
- [x] **New feature**
- [ ] **Dev change**

