### PR TITLE
Feat(messaging): send to user ids

### DIFF
--- a/apps/messaging-api/services/messages/messages.ts
+++ b/apps/messaging-api/services/messages/messages.ts
@@ -19,7 +19,7 @@ export const createMessage = async (params: {
   pg: PostgresDb;
 }): Promise<void> => {
   if (params.payload.message) {
-    return createSingleMessage({
+    return createRawMessage({
       pg: params.pg,
       payload: { ...params.payload, message: params.payload.message! },
     });
@@ -39,7 +39,7 @@ export const createMessage = async (params: {
   )();
 };
 
-const createSingleMessage = async (params: {
+const createRawMessage = async (params: {
   pg: PostgresDb;
   payload: Omit<Required<CreateMessage>, "template">;
 }): Promise<void> => {

--- a/apps/messaging-api/services/users/import/map-users.ts
+++ b/apps/messaging-api/services/users/import/map-users.ts
@@ -292,6 +292,7 @@ const processToImportUser = async (params: {
 
   toImportUser.importStatus = "imported";
   toImportUser.relatedUserProfileId = userProfile?.id;
+  toImportUser.relatedUserId = user.id;
 
   return { user, organisationUser, importedUser: params.toImportUser };
 };

--- a/apps/messaging-api/types/usersSchemaDefinitions.ts
+++ b/apps/messaging-api/types/usersSchemaDefinitions.ts
@@ -1,5 +1,10 @@
 import { Static, Type } from "@sinclair/typebox";
 
+const NullableStringType = Type.Union([Type.Null(), Type.String()], {
+  default: Type.Null(),
+});
+const NullableOptionalStringType = Type.Optional(NullableStringType);
+
 export const InvitationStatusUnionType = Type.Union(
   [
     Type.Literal("to_be_invited"),
@@ -61,10 +66,6 @@ export const CorrelationQualityUnionType = Type.Union([
 ]);
 export type CorrelationQuality = Static<typeof CorrelationQualityUnionType>;
 
-const NullableStringType = Type.Union([Type.Null(), Type.String()], {
-  default: Type.Null(),
-});
-
 export const UserDetailsSchema = Type.Object({
   publicIdentityId: NullableStringType,
   firstName: NullableStringType,
@@ -117,8 +118,9 @@ export const ToImportUserSchema = Type.Composite([
     phoneNumber: NullableStringType,
     emailAddress: NullableStringType,
     importStatus: ImportStatusUnionType,
-    importError: Type.Optional(NullableStringType),
-    relatedUserProfileId: Type.Optional(NullableStringType),
+    importError: NullableOptionalStringType,
+    relatedUserProfileId: NullableOptionalStringType,
+    relatedUserId: NullableOptionalStringType,
     tags: Type.Optional(Type.Array(Type.String())),
   }),
   UserDetailsSchema,
@@ -135,8 +137,6 @@ export const UsersImportSchema = Type.Object({
   importId: Type.String(),
 });
 export type UsersImport = Static<typeof UsersImportSchema>;
-
-const NullableOptionalStringType = Type.Optional(NullableStringType);
 
 export const CsvRecordSchema = Type.Object({
   importIndex: Type.Integer(),


### PR DESCRIPTION
### Description

Now we create messages for both user profile ids, when available, and user ids

In this PR I managed the onboarding part of the flow, next PR will take care of making the createMessage able to search for user profile ids and then for user ids

## Type

- [ ] **Dependency upgrade**
- [ ] **Bug fix**
- [x] **New feature**
- [ ] **Dev change**