### PR TITLE
(Analytics) track userId

### DIFF
--- a/apps/web/app/[locale]/[event]/[...action]/GetDigitalWallet/GetDigitalWallet.tsx
+++ b/apps/web/app/[locale]/[event]/[...action]/GetDigitalWallet/GetDigitalWallet.tsx
@@ -345,6 +345,7 @@ export default async (props: web.NextPageProps) => {
   );
 
   sendAnalytics({
+    userId: userId,
     category: "GetDigitalWallet",
     action: "Verification Level",
     name: `Level ${verificationLevel}`,

--- a/apps/web/app/[locale]/[event]/[...action]/GetDigitalWallet/VerifyLevel0.tsx
+++ b/apps/web/app/[locale]/[event]/[...action]/GetDigitalWallet/VerifyLevel0.tsx
@@ -1,8 +1,10 @@
 import AnalyticsEvent from "analytics/components/AnalyticsEvent";
+import { PgSessions } from "auth/sessions";
 import { getTranslations } from "next-intl/server";
 
 export default async () => {
   const t = await getTranslations("GetDigitalWallet.VerifyAccountLevel0");
+  const { userId } = await PgSessions.get();
   return (
     <div className="govie-grid-row">
       <div className="govie-grid-column-two-thirds-from-desktop">
@@ -31,6 +33,7 @@ export default async () => {
         </p>
       </div>
       <AnalyticsEvent
+        userId={userId}
         category="GetDigitalWallet"
         action="Verification Level"
         name="Level 0"

--- a/apps/web/app/[locale]/[event]/[...action]/GetDigitalWallet/VerifyLevel1.tsx
+++ b/apps/web/app/[locale]/[event]/[...action]/GetDigitalWallet/VerifyLevel1.tsx
@@ -1,8 +1,10 @@
 import AnalyticsEvent from "analytics/components/AnalyticsEvent";
+import { PgSessions } from "auth/sessions";
 import { getTranslations } from "next-intl/server";
 
 export default async () => {
   const t = await getTranslations("GetDigitalWallet.VerifyAccountLevel1");
+  const { userId } = await PgSessions.get();
   return (
     <div className="govie-grid-row">
       <div className="govie-grid-column-two-thirds-from-desktop">
@@ -31,6 +33,7 @@ export default async () => {
         </p>
       </div>
       <AnalyticsEvent
+        userId={userId}
         category="GetDigitalWallet"
         action="Verification Level"
         name="Level 1"

--- a/apps/web/app/[locale]/layout.tsx
+++ b/apps/web/app/[locale]/layout.tsx
@@ -77,6 +77,7 @@ export default async function RootLayout({
         }}
       >
         <AnalyticsTracker
+          userId={userId}
           customDimensions={{ dimension1: verificationLevel }}
         />
 

--- a/packages/analytics/components/AnalyticsTracker.tsx
+++ b/packages/analytics/components/AnalyticsTracker.tsx
@@ -28,7 +28,16 @@ export default function AnalyticsTracker({
     return null;
   }
 
+  const pathname = usePathname();
+  const isInitialLoad = useRef(true);
+  const isInitialized = useRef(false);
+
   const initFunction = () => {
+    // if it's not the initial load, we don't need to set the userId and customDimensions
+    if (!isInitialLoad.current) {
+      return;
+    }
+
     if (userId) {
       push(["setUserId", userId]);
     }
@@ -40,18 +49,22 @@ export default function AnalyticsTracker({
     }
   };
 
-  const pathname = usePathname();
-  const isInitialLoad = useRef(true);
-
   useEffect(() => {
+    if (isInitialized.current) {
+      return;
+    }
+
     init({
       url: MATOMO_URL,
       siteId: MATOMO_SITE_ID,
       disableCookies: true,
       onInitialization: initFunction,
     });
+
+    isInitialized.current = true;
+
     return () => push(["HeatmapSessionRecording::disable"]);
-  }, []);
+  }, [MATOMO_URL, MATOMO_SITE_ID, userId]);
 
   useEffect(() => {
     if (isInitialLoad.current) {


### PR DESCRIPTION
### Ticket:

- [17655](https://dev.azure.com/OGCIO-Digital-Services/Digital%20Services%20Programme/_workitems/edit/17655)

### Description

As per Aoife's request, we will also track the userId when sending analytics events.

This also fixes an issue with some Matomo events being request twice, which would cause an error log to be displayed in the console.

## Type

- [ ] **Dependency upgrade**
- [x] **Bug fix**
- [x] **New feature**
- [ ] **Dev change**

### Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This change might impact the developer experience of others and should be communicated

### Screenshots:

N/A
