### PR TITLE
[BB landing page] Fix login

### DIFF
--- a/apps/home/.env.sample
+++ b/apps/home/.env.sample
@@ -7,7 +7,7 @@ NEXT_PUBLIC_MATOMO_SITE_ID=14
 NEXT_PUBLIC_MATOMO_PROTOCOL=https
 
 LOGTO_ENDPOINT=http://localhost:3301/
-LOGTO_HOME_APP_ID=home_app_id
+LOGTO_HOME_APP_ID=4icd76x8we31j1e8bqyfn
 LOGTO_HOME_APP_SECRET=home_app_local_secret
 LOGTO_COOKIE_SECRET=home_app_local_secret
 

--- a/packages/auth/src/auth-session.ts
+++ b/packages/auth/src/auth-session.ts
@@ -46,15 +46,6 @@ export const AuthSession: IAuthSession = {
     config: LogtoNextConfig,
     getContextParameters: GetSessionContextParameters,
   ): Promise<PartialAuthSessionContext> {
-    if (
-      getContextParameters.userType === "publicServant" &&
-      !getContextParameters.organizationId
-    ) {
-      throw new BadRequestError(
-        PROCESS_ERROR,
-        "Organization id is mandatory when logging in as public servant",
-      );
-    }
     addInactivePublicServantScope(config);
     let context;
     try {


### PR DESCRIPTION
### Ticket:

- [20214](https://dev.azure.com/OGCIO-Digital-Services/Digital%20Services%20Programme/_workitems/edit/20214)

### Description

<!-- Please include a summary of the changes and the related issue. -->
Public servants need to be able to login in BB landing page and retrieve the Logto context without providing an organization id.

## Type

- [ ] **Dependency upgrade**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Dev change**

### Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This change might impact the developer experience of others and should be communicated

### Screenshots:

N/A
