### PR TITLE
FIX: Avoid artifact downloading to speed up validation

### DIFF
--- a/azure_pipelines.yml
+++ b/azure_pipelines.yml
@@ -77,6 +77,7 @@ stages:
         runOnce:
           deploy:
             steps:
+            - download: none
             - script: |
                 date
               displayName: Show current date


### PR DESCRIPTION
### Ticket:

- N/A

### Description

Pipeline deployment was failing due to the azure pipeline runner being out of space. Introducing now changes to avoid artifact downloading, as we don't need it to validate whether we can deploy or not to the service.

## Type

- [ ] **Dependency upgrade**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Dev change**

### Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This change might impact the developer experience of others and should be communicated

### Screenshots:

N/A
