### PR TITLE
[Payments] E2E - Identify unique transaction by payment reference code

### DIFF
--- a/apps/payments-api/openapi-definition.yml
+++ b/apps/payments-api/openapi-definition.yml
@@ -1330,6 +1330,8 @@ paths:
                                 - failed
                         amount:
                           type: number
+                        extPaymentId:
+                          type: string
                         updatedAt:
                           type: string
                         title:
@@ -1338,6 +1340,7 @@ paths:
                         - transactionId
                         - status
                         - amount
+                        - extPaymentId
                         - updatedAt
                         - title
                   metadata:
@@ -1429,11 +1432,13 @@ paths:
                               - failed
                       amount:
                         type: number
+                      extPaymentId:
+                        allOf:
+                          - type: string
+                          - type: string
                       updatedAt:
                         type: string
                       title:
-                        type: string
-                      extPaymentId:
                         type: string
                       userId:
                         type: string
@@ -1457,9 +1462,9 @@ paths:
                       - transactionId
                       - status
                       - amount
+                      - extPaymentId
                       - updatedAt
                       - title
-                      - extPaymentId
                       - userId
                       - userData
                       - providerName
@@ -1654,11 +1659,13 @@ paths:
                                 - failed
                         amount:
                           type: number
+                        extPaymentId:
+                          allOf:
+                            - type: string
+                            - type: string
                         updatedAt:
                           type: string
                         title:
-                          type: string
-                        extPaymentId:
                           type: string
                         userId:
                           type: string
@@ -1682,9 +1689,9 @@ paths:
                         - transactionId
                         - status
                         - amount
+                        - extPaymentId
                         - updatedAt
                         - title
-                        - extPaymentId
                         - userId
                         - userData
                         - providerName
@@ -2261,11 +2268,13 @@ paths:
                               - failed
                       amount:
                         type: number
+                      extPaymentId:
+                        allOf:
+                          - type: string
+                          - type: string
                       updatedAt:
                         type: string
                       title:
-                        type: string
-                      extPaymentId:
                         type: string
                       userId:
                         type: string
@@ -2289,9 +2298,9 @@ paths:
                       - transactionId
                       - status
                       - amount
+                      - extPaymentId
                       - updatedAt
                       - title
-                      - extPaymentId
                       - userId
                       - userData
                       - providerName

--- a/apps/payments-api/package.json
+++ b/apps/payments-api/package.json
@@ -10,7 +10,7 @@
     "start": "node dist/index.js",
     "dev": "nodemon | pino-pretty",
     "lint": "eslint . --ext .ts",
-    "generate-ts-client": "npx openapi-typescript ./openapi-definition.yml -o ../../packages/building-blocks-sdk/services/payments/schema.d.ts",
+    "generate-ts-client": "npx openapi-typescript ./openapi-definition.yml -o ../../packages/building-blocks-sdk/src/services/payments/schema.d.ts",
     "build": "rm -rf dist && tsc -p tsconfig.prod.json && cp logo.png dist/"
   },
   "nodemonConfig": {

--- a/apps/payments-api/plugins/entities/transactions/repo.ts
+++ b/apps/payments-api/plugins/entities/transactions/repo.ts
@@ -142,6 +142,7 @@ export class TransactionsRepo {
         t.status,
         pr.title,
         pt.amount,
+        t.ext_payment_id as "extPaymentId",
         t.updated_at as "updatedAt"
       FROM payment_transactions t
       INNER JOIN payment_requests pr ON pr.payment_request_id = t.payment_request_id

--- a/apps/payments-api/routes/schemas/index.ts
+++ b/apps/payments-api/routes/schemas/index.ts
@@ -197,6 +197,7 @@ export const Transaction = Type.Composite([
     "transactionId",
     "status",
     "amount",
+    "extPaymentId",
     "updatedAt",
   ]),
   Type.Object({

--- a/apps/payments/app/[locale]/(hosted)/paymentRequest/openbanking/OpenBankingHost.tsx
+++ b/apps/payments/app/[locale]/(hosted)/paymentRequest/openbanking/OpenBankingHost.tsx
@@ -35,6 +35,7 @@ export default function Page(props: Props) {
 
         const url = new URL(props.returnUri);
         url.searchParams.append("error", "aborted");
+        url.searchParams.append("payment_id", props.paymentId);
         router.push(url.href);
       },
       onError: () => {
@@ -42,6 +43,7 @@ export default function Page(props: Props) {
 
         const url = new URL(props.returnUri);
         url.searchParams.append("error", "error");
+        url.searchParams.append("payment_id", props.paymentId);
         router.push(url.href);
       },
       onLoad: () => {

--- a/apps/payments/app/[locale]/(hosted)/paymentSetup/requests/[requestId]/page.tsx
+++ b/apps/payments/app/[locale]/(hosted)/paymentSetup/requests/[requestId]/page.tsx
@@ -91,7 +91,11 @@ export default async function ({
                   </thead>
                   <tbody className="govie-table__body">
                     {transactionsResponse?.data.map((trx) => (
-                      <tr className="govie-table__row" key={trx.transactionId}>
+                      <tr
+                        className="govie-table__row"
+                        key={trx.transactionId}
+                        data-reference-code={trx.extPaymentId}
+                      >
                         <td className="govie-table__cell govie-table__cell--vertical-centralized govie-body-s">
                           <strong
                             className={`govie-tag ${mapTransactionStatusColorClassName(trx.status)} govie-body-s`}

--- a/apps/payments/e2e/objects/paymentRequests/PaymentRequestDetailsPage.ts
+++ b/apps/payments/e2e/objects/paymentRequests/PaymentRequestDetailsPage.ts
@@ -175,6 +175,7 @@ export class PaymentRequestDetailsPage {
     transactions: {
       amount: string;
       status: string;
+      referenceCode: string;
     }[],
   ) {
     await expect(
@@ -190,12 +191,18 @@ export class PaymentRequestDetailsPage {
     }
 
     for (const transaction of transactions) {
-      const transactionRow = await this.page
-        .getByRole("row")
-        .filter({ hasText: transaction.status })
-        .filter({ hasText: transaction.amount })
-        .filter({ hasText: "Details" });
-      await expect(transactionRow).toBeVisible();
+      const transactionRow = await this.page.locator(
+        `tr[data-reference-code="${transaction.referenceCode}"]`,
+      );
+      await expect(
+        transactionRow.getByRole("cell", { name: transaction.amount }),
+      ).toBeVisible();
+      await expect(
+        transactionRow.getByRole("cell", { name: transaction.status }),
+      ).toBeVisible();
+      await expect(
+        transactionRow.getByRole("link", { name: "Details" }),
+      ).toBeVisible();
     }
   }
 }

--- a/apps/payments/e2e/objects/payments/ManualBankTransferTransactionPage.ts
+++ b/apps/payments/e2e/objects/payments/ManualBankTransferTransactionPage.ts
@@ -70,7 +70,7 @@ export class ManualBankTransferTransactionPage {
       .locator("dt")
       .last();
     await expect(referenceCodeCell).toBeVisible();
-    return referenceCodeCell.innerText();
+    return (await referenceCodeCell.innerText()).trim();
   }
 
   async getAmount() {

--- a/apps/payments/e2e/objects/payments/openbanking/CancelPaymentComponent.ts
+++ b/apps/payments/e2e/objects/payments/openbanking/CancelPaymentComponent.ts
@@ -23,6 +23,9 @@ export class CancelPaymentComponent {
   async proceedAndCancelPayment() {
     await expect(this.header).toBeVisible();
     await this.optionBtn.click();
+
+    // sometimes Playwright finds the button outside of the viewport and can't click it even after scrolling into view
+    await this.page.setViewportSize({ width: 1920, height: 1080 });
     await this.proceedBtn.click();
   }
 }

--- a/apps/payments/e2e/specs/transactions/manualBankTransfer.spec.ts
+++ b/apps/payments/e2e/specs/transactions/manualBankTransfer.spec.ts
@@ -64,11 +64,22 @@ test.describe("Transaction with manual bank transfer", () => {
     );
     await manualBankTransferTransactionPage.checkIban(mockIban);
     await manualBankTransferTransactionPage.checkReferenceCode();
+    const referenceCode =
+      await manualBankTransferTransactionPage.getReferenceCode();
     await manualBankTransferTransactionPage.confirmPayment();
 
     await expect(citizenPage).toHaveURL(mockRedirectUrl);
     await expect(
       citizenPage.getByRole("img", { name: "Google" }),
     ).toBeVisible();
+
+    await paymentRequestsPage.goto();
+    await paymentRequestsPage.gotoDetails(
+      paymentRequestWithManualBankTransferProvider,
+    );
+
+    await detailsPage.checkPaymentsList([
+      { amount: mockAmount, status: "pending", referenceCode },
+    ]);
   });
 });

--- a/apps/payments/e2e/utils/constants.ts
+++ b/apps/payments/e2e/utils/constants.ts
@@ -12,6 +12,10 @@ export const myGovIdMockSettings = {
   citizenEmailDomain: "mail.ie",
 };
 
+export const referenceCodeSearchParam = {
+  openBanking: "payment_id",
+};
+
 export const BankTransferProviderValidationErrors = [
   "nameRequired",
   "accountHolderNameRequired",

--- a/packages/building-blocks-sdk/src/services/payments/schema.d.ts
+++ b/packages/building-blocks-sdk/src/services/payments/schema.d.ts
@@ -623,6 +623,7 @@ export interface paths {
                   | "cancelled"
                   | "failed";
                 amount: number;
+                extPaymentId: string;
                 updatedAt: string;
                 title: string;
               }[];
@@ -678,9 +679,9 @@ export interface paths {
                   | "cancelled"
                   | "failed";
                 amount: number;
+                extPaymentId: string & string;
                 updatedAt: string;
                 title: string;
-                extPaymentId: string;
                 userId: string;
                 userData: {
                   name: string;
@@ -796,9 +797,9 @@ export interface paths {
                   | "cancelled"
                   | "failed";
                 amount: number;
+                extPaymentId: string & string;
                 updatedAt: string;
                 title: string;
-                extPaymentId: string;
                 userId: string;
                 userData: {
                   name: string;
@@ -1128,9 +1129,9 @@ export interface paths {
                   | "cancelled"
                   | "failed";
                 amount: number;
+                extPaymentId: string & string;
                 updatedAt: string;
                 title: string;
-                extPaymentId: string;
                 userId: string;
                 userData: {
                   name: string;


### PR DESCRIPTION
### Ticket:

- [20086](https://dev.azure.com/OGCIO-Digital-Services/Digital%20Services%20Programme/_workitems/edit/20086)

### Description

<!-- Please include a summary of the changes and the related issue. -->
Use payment reference code to identify unique transactions in payment request details page transactions list. The same approach can in case be used in other transactions list and with transactions process by different providers.
If the payment is made with open banking or stripe and is successful we intercept the network responses with Playwright API to get the external payment id (aka payment reference code) passed as search param in our temporary redirection page.

## Type

- [ ] **Dependency upgrade**
- [ ] **Bug fix**
- [ ] **New feature**
- [x] **Dev change**
- [ ] **Additional tests**
- [ ] **Documentation**
- [ ] **Other**

### Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This change might impact the developer experience of others and should be communicated

### Screenshots:

N/A
