### PR TITLE
chore(profile-api) Chaged email lookup behavior for profile-api

### DIFF
--- a/apps/profile-api/services/users/find-user.ts
+++ b/apps/profile-api/services/users/find-user.ts
@@ -139,20 +139,16 @@ const findByEmailAddress = async (params: {
   findUserParams: FindUserParams;
 }): Promise<FoundUser | undefined> => {
   const userParams = params.findUserParams;
-  if (!userParams.firstname || !userParams.lastname || !userParams.email) {
+  if (!userParams.email) {
     return undefined;
   }
 
-  const query = buildFindQuery([
-    "firstname ILIKE $1",
-    "lastname ILIKE $2",
-    "email ILIKE $3",
-  ]);
+  const query = buildFindQuery(["email ILIKE $1"]);
 
   const found = await runFindQuery({
     client: params.client,
     query,
-    values: [userParams.firstname, userParams.lastname, userParams.email],
+    values: [userParams.email],
   });
 
   return found ? { ...found, matchQuality: "exact" } : undefined;


### PR DESCRIPTION
### Description

- Changed query behaviour to allow queries by email-address only

## Type

- [ ] **Dependency upgrade**
- [ ] **Bug fix**
- [ ] **New feature**
- [x] **Dev change**
- [ ] **Additional tests**
- [ ] **Documentation**
- [ ] **Other**

### Checklist:

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] This change might impact the developer experience of others and should be communicated

### Screenshots:

N/A
