### PR TITLE
Fix(messaging): use correct org id

### DIFF
--- a/apps/messaging/app/[locale]/settings/Organisations.tsx
+++ b/apps/messaging/app/[locale]/settings/Organisations.tsx
@@ -31,8 +31,7 @@ export default async () => {
         {data?.map((organisationSetting) => (
           <tr className="govie-table__row" key={organisationSetting.id}>
             <th className="govie-table__header govie-table__header--vertical-centralized govie-body-s">
-              {/* {invitation.organisationId} At the moment we want to show "Life Events" as fixed value*/}
-              Life Events
+              {organisationSetting.organisationId}
             </th>
             <td className="govie-table__cell govie-table__cell--vertical-centralized govie-body-s">
               {organisationSetting.organisationInvitationStatus}

--- a/apps/messaging/app/[locale]/settings/organisations/[organisationSettingId]/page.tsx
+++ b/apps/messaging/app/[locale]/settings/organisations/[organisationSettingId]/page.tsx
@@ -119,10 +119,7 @@ export default async (props: { params: { organisationSettingId: string } }) => {
       <h1>
         <span className="govie-heading-l">{t("title")}</span>
       </h1>
-      <p className="govie-body">
-        {/* {organisationId} At the moment we want "Life Events" as fixed value */}
-        Life Events
-      </p>
+      <p className="govie-body">{configurations.data?.organisationId}</p>
       <form action={submitAction}>
         <input
           name="organisationSettingId"


### PR DESCRIPTION
### Description

Removed the fixed `Life Events` label in favor of org id

## Type

- [ ] **Dependency upgrade**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Dev change**
- [ ] **Additional tests**
- [ ] **Documentation**
- [ ] **Other**
