### PR TITLE
Fix(messaging-api): message actions permission

### DIFF
--- a/apps/messaging-api/src/routes/message-actions/index.ts
+++ b/apps/messaging-api/src/routes/message-actions/index.ts
@@ -32,7 +32,7 @@ export default async function messagesActions(app: FastifyInstance) {
     "/:messageId",
     {
       preValidation: (req, res) =>
-        app.checkPermissions(req, res, [Permissions.CitizenSelf.Write]),
+        app.checkPermissions(req, res, [Permissions.MessageSelf.Write]),
       schema: {
         tags: ["Message actions"],
         body: MessageActions,


### PR DESCRIPTION
### Description

Replaces citizen self with message self for message actions

## Type

- [ ] **Dependency upgrade**
- [x] **Bug fix**
- [ ] **New feature**
- [ ] **Dev change**
- [ ] **Additional tests**
- [ ] **Documentation**
- [ ] **Other**